### PR TITLE
Input component bug

### DIFF
--- a/src/input/Input.js
+++ b/src/input/Input.js
@@ -106,7 +106,7 @@ class Input extends Component {
             </View>
           )}
         </Animated.View>
-        {errorMessage && (
+        {!!errorMessage && (
           <Text style={[styles.error, errorStyle && errorStyle]}>
             {errorMessage}
           </Text>


### PR DESCRIPTION
App is failed when input component error message prop is set to empty string(example ''), because empty string should be wrap in text component. We have it from this operation: 
 errorMessage && (
          <Text style={[styles.error, errorStyle && errorStyle]}>
            {errorMessage}
          </Text>
I added !! to check properly errorMessage. This is not an only solution.